### PR TITLE
Add Nano public node count and source

### DIFF
--- a/_data/coins/nano.yml
+++ b/_data/coins/nano.yml
@@ -9,6 +9,6 @@ wealth_distribution: 63%
 wealth_distribution_source: https://raiblocks.net/page/frontiers.php
 client_codebases:
 client_codebases_source:
-public_nodes:
-public_nodes_source:
+public_nodes: 3520
+public_nodes_source: https://nano.org/en/explore/representatives
 notes: The "Official Representatives" are run by the developers, hence can be collapsed to represent a single entity


### PR DESCRIPTION
The public nodes number comes from https://nano.org/en/explore/representatives, also https://raiblocks.net/page/representatives is the legacy version of this site.  Other "non official" resources for nodes with non-zero balance includes https://www.nanode.co/representatives and http://xrb.network/.  This number is not static and is updated regularly using different intervals between each site.  Node count can also be obtained directly from a full node using the following command:

```rai_node --debug-dump-representatives```

The above command includes nodes with '^0$' weight which all sources above do not seem to include.  