### PR TITLE
Update Ripple XRP

### DIFF
--- a/_data/coins/ripple.yml
+++ b/_data/coins/ripple.yml
@@ -4,11 +4,11 @@ url: https://ripple.com/
 consensus: RPCA (voting system)
 incentivized: N
 consensus_distribution: 1
-consensus_distribution_source: https://blog.bitmex.com/the-ripple-story/
+consensus_distribution_source: https://ripple.com/dev-blog/decentralization-strategy-update/
 wealth_distribution: 97%
 wealth_distribution_source: https://ledger.exposed/rich-stats/100
-client_codebases:
-client_codebases_source:
-public_nodes:
-public_nodes_source:
-notes: By default, rippled only points to 5 Ripple-owned validator nodes. User would have to edit a config file to change this - hence only 1 entity owning consensus by default
+client_codebases: 1
+client_codebases_source: https://xrpcharts.ripple.com/#/topology
+public_nodes: 596
+public_nodes_source: https://xrpcharts.ripple.com/#/topology
+notes: By default, rippled only points to a list of only Ripple-operated validator nodes (currently 16) at https://vl.ripple.com (https://github.com/ripple/rippled/blob/develop/cfg/validators-example.txt). Node operators would have to edit a config file to change this or choose their own list - hence only 1 entity owning consensus by default.


### PR DESCRIPTION
* Replace BitMex article with https://ripple.com/dev-blog/decentralization-strategy-update/ (quote about current centralization: "So far, most of that trust has relied upon validators owned and controlled by Ripple, the company leading development of the XRP Ledger. Ripple chose deliberately to be the most trusted validator operator in the network during the initial stages of development of the XRP Ledger.")
* Add number for client codebases (there's only one other known server implementation and it doesn't have code to take part in consensus, only to serve data)
* Add current number of public nodes
* Add sources for client code bases and current number of nodes
* Correct the notes (there are 16, not 5 validators at the moment - all Ripple operated) and cite code/sources directly