### PR TITLE
Fix public node count for NANO

### DIFF
--- a/_data/coins/nano.yml
+++ b/_data/coins/nano.yml
@@ -9,6 +9,6 @@ wealth_distribution: 63%
 wealth_distribution_source: https://raiblocks.net/page/frontiers.php
 client_codebases:
 client_codebases_source:
-public_nodes: 3520
-public_nodes_source: https://nano.org/en/explore/representatives
+public_nodes: 648
+public_nodes_source: https://nano.org/en/explore/peers
 notes: The "Official Representatives" are run by the developers, hence can be collapsed to represent a single entity


### PR DESCRIPTION
A representative is simply an account that is delegated voting weight. It does not have to be online and nodes can represent multiple addresses at the same time. If you want the actual node count, you have to look at the number of connected peers.