### PR TITLE
Update the % money supply held by top 100 accouts for XRP:

### DIFF
--- a/_data/coins/ripple.yml
+++ b/_data/coins/ripple.yml
@@ -5,8 +5,8 @@ consensus: RPCA (voting system)
 incentivized: N
 consensus_distribution: 1
 consensus_distribution_source: https://ripple.com/dev-blog/decentralization-strategy-update/
-wealth_distribution: 98%
-wealth_distribution_source: https://ledger.exposed/rich-stats/100/0
+wealth_distribution: 38.34%
+wealth_distribution_source: https://ledger.exposed/rich-stats
 client_codebases: 1
 client_codebases_source: https://xrpcharts.ripple.com/#/topology
 public_nodes: 596


### PR DESCRIPTION
The data source continues to be https://ledger.exposed/rich-stats

The percentage is calculated as follows:

    sum(top 100 wallets) / (total XRP)

The calculation is against the total amount of XRP available. This amount will decrease over time as XRP used to pay for fees is destroyed.

As of this writing, the numbers are:

| Description        | Amount |
| ------------- | -----|
| Sum(top 100 wallets exclusive of escrow) | 38,337,799,799 XRP |
| Sum(all wallets, exclusive of escrow) | 47,291,885,259 XRP |
| Total available XRP | 99,992,216,935 XRP |