### PR TITLE
Update Ripple Top 100

### DIFF
--- a/_data/coins/ripple.yml
+++ b/_data/coins/ripple.yml
@@ -5,8 +5,8 @@ consensus: RPCA (voting system)
 incentivized: N
 consensus_distribution: 1
 consensus_distribution_source: https://ripple.com/dev-blog/decentralization-strategy-update/
-wealth_distribution: 98%
-wealth_distribution_source: https://ledger.exposed/rich-stats/100/0
+wealth_distribution: 81%
+wealth_distribution_source: https://ledger.exposed/rich-stats
 client_codebases: 1
 client_codebases_source: https://xrpcharts.ripple.com/#/topology
 public_nodes: 596


### PR DESCRIPTION
Based on PR #29, but after some discussion:

`SUM(Non-escrowed XRP Top 100 accounts) / SUM(Non-escrowed XRP accounts) * 100`

The [source website](https://ledger.exposed/rich-stats) is updated to initially display the same number and calculation.

![image](https://user-images.githubusercontent.com/4756161/39977916-58c26510-573d-11e8-8008-ca0854c2b105.png)
