### PR TITLE
Update Dash consensus_distribution

### DIFF
--- a/_data/coins/dash.yml
+++ b/_data/coins/dash.yml
@@ -3,7 +3,7 @@ symbol: DASH
 url: https://dash.org
 consensus: PoW
 incentivized: Y
-consensus_distribution: 2
+consensus_distribution: 3
 consensus_distribution_source: https://chainz.cryptoid.info/dash/#!extraction
 wealth_distribution: 14%
 wealth_distribution_source: https://bitinfocharts.com/top-100-richest-dash-addresses.html


### PR DESCRIPTION
Consensus distribution should not count "All others" since this is by definition not a single entity.