### PR TITLE
Update iota.yml

### DIFF
--- a/_data/coins/iota.yml
+++ b/_data/coins/iota.yml
@@ -9,6 +9,6 @@ wealth_distribution: 62%
 wealth_distribution_source: https://thetangle.org/statistics/richest-addresses
 client_codebases: 1
 client_codebases_source: https://github.com/iotaledger/iri
-public_nodes: 23
-public_nodes_source: https://iota.dance/nodes
+public_nodes: 484
+public_nodes_source: https://iota-nodes.net/statistics
 notes: There is no automatic peer discover in IOTA, so total full nodes is unknown since most are not public. Full nodes are recommended to not consider a transaction to be confirmed on the IOTA Network until referenced by the "coordinator", a centralized node controlled by the IOTA Foundation.


### PR DESCRIPTION
I'm the developer behind iota-nodes.net. I've created an automated nodelist using the nelson peer discovery protocol. The total amount of public nodes is larger than the provided amount. Not all nodes are using the nelson protocol and therefore the real number can't be determined. Since the nelson protocol has a big share the provided number can be used as a good approximation. The current number of public nodes using the nelson protocol can always be found  on https://iota-nodes.net/statistics and is refreshed hourly.