### PR TITLE
Increase Dash consensus_distribution to 4

### DIFF
--- a/_data/coins/dash.yml
+++ b/_data/coins/dash.yml
@@ -3,7 +3,7 @@ symbol: DASH
 url: https://dash.org
 consensus: PoW
 incentivized: Y
-consensus_distribution: 3
+consensus_distribution: 4
 consensus_distribution_source: https://chainz.cryptoid.info/dash/#!extraction
 wealth_distribution: 15%
 wealth_distribution_source: https://bitinfocharts.com/top-100-richest-dash-addresses.html


### PR DESCRIPTION
Based on https://chainz.cryptoid.info/dash/#!extraction and excluding "all others", 4 pools are now required to exceed 50% of hashrate over both last 100 and last 1000 blocks. This is likely due to Bitmain selling off D3 miners on second hand market.