### PR TITLE
updated ripple.yml

### DIFF
--- a/_data/coins/ripple.yml
+++ b/_data/coins/ripple.yml
@@ -3,12 +3,12 @@ symbol: XRP
 url: https://ripple.com/
 consensus: RPCA (voting system)
 incentivized: N
-consensus_distribution: 1
+consensus_distribution: 2
 consensus_distribution_source: https://ripple.com/dev-blog/decentralization-strategy-update/
 wealth_distribution: 81%
 wealth_distribution_source: https://ledger.exposed/rich-stats
 client_codebases: 1
 client_codebases_source: https://xrpcharts.ripple.com/#/topology
-public_nodes: 732
+public_nodes: 789
 public_nodes_source: https://xrpcharts.ripple.com/#/topology
-notes: By default, rippled only points to a list of only Ripple-operated validator nodes (currently 16) at https://vl.ripple.com (https://github.com/ripple/rippled/blob/develop/cfg/validators-example.txt). Node operators would have to edit a config file to change this or choose their own list - hence only 1 entity owning consensus by default.
+notes: By default, rippled only points to a list of only Ripple-operated validator nodes (currently 21) at https://vl.ripple.com (https://github.com/ripple/rippled/blob/develop/cfg/validators-example.txt). Node operators would have to edit a config file to change this or choose their own list - hence only 1 entity owning consensus by default.

--- a/_data/coins/ripple.yml
+++ b/_data/coins/ripple.yml
@@ -11,4 +11,4 @@ client_codebases: 1
 client_codebases_source: https://xrpcharts.ripple.com/#/topology
 public_nodes: 789
 public_nodes_source: https://xrpcharts.ripple.com/#/topology
-notes: By default, rippled only points to a list of only Ripple-operated validator nodes (currently 21) at https://vl.ripple.com (https://github.com/ripple/rippled/blob/develop/cfg/validators-example.txt). Node operators would have to edit a config file to change this or choose their own list - hence only 1 entity owning consensus by default.
+notes: The default validator list can be visualized at https://minivalist.cinn.app/ but individual server operators can edit a configuration file to specify a different list.

--- a/_data/coins/xrp.yml
+++ b/_data/coins/xrp.yml
@@ -1,6 +1,6 @@
-name: Ripple
+name: XRP
 symbol: XRP
-url: https://ripple.com/
+url: https://ripple.com/xrp/
 consensus: RPCA (voting system)
 incentivized: N
 consensus_distribution: 2


### PR DESCRIPTION
updated ripple consensus variable, ripple nolonger maintains >50% of the default UNL's validators (see: https://minivalist.cinn.app/)