### PR TITLE
Update consensus_distribution

### DIFF
--- a/_data/coins/dash.yml
+++ b/_data/coins/dash.yml
@@ -3,7 +3,7 @@ symbol: DASH
 url: https://dash.org
 consensus: PoW
 incentivized: Y
-consensus_distribution: 3
+consensus_distribution: 4
 consensus_distribution_source: https://chainz.cryptoid.info/dash/#!extraction
 wealth_distribution: 14.65%
 wealth_distribution_source: https://bitinfocharts.com/top-100-richest-dash-addresses.html


### PR DESCRIPTION
Revert to 4. I believe @sabotagebeats edit was incorrect, consensus_distribution should not count "all others" as a discrete mining pool since it is by definition comprised of all other pools. Dash hashrate distribution would require at least 4 pools for >50% of hashrate on both the 100 and 1000 block histories.