### PR TITLE
Update XRP information:

### DIFF
--- a/_data/coins/xrp.yml
+++ b/_data/coins/xrp.yml
@@ -3,12 +3,12 @@ symbol: XRP
 url: https://ripple.com/xrp/
 consensus: RPCA (voting system)
 incentivized: N
-consensus_distribution: 2
-consensus_distribution_source: https://ripple.com/dev-blog/decentralization-strategy-update/
-wealth_distribution: 81%
+consensus_distribution: 4
+consensus_distribution_source: https://minivalist.cinn.app/validators
+wealth_distribution: 79.97%
 wealth_distribution_source: https://ledger.exposed/rich-stats
 client_codebases: 1
 client_codebases_source: https://xrpcharts.ripple.com/#/topology
-public_nodes: 789
+public_nodes: 918
 public_nodes_source: https://xrpcharts.ripple.com/#/topology
-notes: The default validator list can be visualized at https://minivalist.cinn.app/ but individual server operators can edit a configuration file to specify a different list.
+notes: The default validator list can be visualized at https://minivalist.cinn.app/validators but individual server operators can edit a configuration file to specify a different list.


### PR DESCRIPTION
- As of October 15, 61% of validators on the recommended UNL are operated by third parties. A minimum of 4 independent entities are now required to meet the 50% threshold that AWDY uses as a comparison.
- Update the XRP distribution using the latest figures from https://ledger.exposed/rich-stats
- Update the node distribution using the latest figures from https://xrpcharts.ripple.com/#/topology