### PR TITLE
Fixed XRP and DGB stats

### DIFF
--- a/_data/coins/digibyte.yml
+++ b/_data/coins/digibyte.yml
@@ -3,12 +3,12 @@ symbol: DGB
 url: https://digibyte.io
 consensus: PoW
 incentivized: Y
-consensus_distribution: 3
+consensus_distribution: 6
 consensus_distribution_source: https://chainz.cryptoid.info/dgb/#!extraction
-wealth_distribution: 46.66%
+wealth_distribution: 44.74
 wealth_distribution_source: https://chainz.cryptoid.info/dgb/#!rich
 client_codebases: 1
 client_codebases_source: https://chainz.cryptoid.info/dgb/#!network
-public_nodes: 287
-public_nodes_source: https://chainz.cryptoid.info/dgb/#!network
-notes: Because DigiByte is MultiAlgo, to perform a 51% attack, it would require 93% of the primary attack algorithm and 51% of all other remaining, meaning the Consensus Distribution is skewed
+public_nodes: ?
+public_nodes_source: 
+notes: No known node is running with publicly available stats that has higher than default peers, though DigiExplorer.info has over 800 active connections

--- a/_data/coins/xrp.yml
+++ b/_data/coins/xrp.yml
@@ -3,12 +3,12 @@ symbol: XRP
 url: https://ripple.com/xrp/
 consensus: RPCA (voting system)
 incentivized: N
-consensus_distribution: 2
-consensus_distribution_source: https://ripple.com/dev-blog/decentralization-strategy-update/
+consensus_distribution: 1
+consensus_distribution_source: https://developers.ripple.com/technical-faq.html
 wealth_distribution: 81%
 wealth_distribution_source: https://ledger.exposed/rich-stats
 client_codebases: 1
 client_codebases_source: https://xrpcharts.ripple.com/#/topology
-public_nodes: 789
-public_nodes_source: https://xrpcharts.ripple.com/#/topology
-notes: The default validator list can be visualized at https://minivalist.cinn.app/ but individual server operators can edit a configuration file to specify a different list.
+public_nodes: 23
+public_nodes_source: https://minivalist.cinn.app/validators
+notes: The default UNL can be seen at https://minivalist.cinn.app however Ripple controls the UNL: https://developers.ripple.com/technical-faq.html and non-standard nodes must be manually 'trusted' as there is no auto-discovery


### PR DESCRIPTION
Ripple controls the default UNL (and 9/23 nodes on it at present).
Adding any nodes must be "known" and "trusted" by the user (As the trust is required for consensus that the 3rd-party will not act maliciously). This is wholly controlled by Ripple as mentioned at https://developers.ripple.com/technical-faq.html under "What is Ripple’s process for reviewing third-party code contributions before they go live in the master codebase?"
This is an important distinction due to the way the RPCA consensus is achieved, as nothing is "staked", and nor is there any PoW.

Fixed DGB stats (No real need to keep the multi-algo blurb in there, it doesn't offer much).
Mining distribution is regularly 7-10, needed for 51%, especially on 1000 block stats, but number is conservative over previous 100 blocks at only 6 needed.
No public 'stats' server currently exists for DigiByte with maxconnections= specified higher than default, however, DigiExplorer.info currently has over 800 so rounded down to be conservative.